### PR TITLE
feat(gatsby-node): retrieve API data during build

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,37 @@
+const fetch = require('node-fetch')
+const md5 = require('md5')
+
+const getKey = () => {
+  const timestamp = Date.now()
+  const privateKey = process.env.GATSBY_MARVEL_PRIVATE_KEY
+  const publicKey = process.env.GATSBY_MARVEL_PUBLIC_KEY
+  const hash = md5(timestamp + privateKey + publicKey)
+  return {
+    timestamp,
+    publicKey,
+    hash,
+  }
+}
+
+exports.sourceNodes = async () => {
+  const key = getKey()
+  const auth = `ts=${key.timestamp}&apikey=${key.publicKey}&hash=${key.hash}`
+  const character = 'Iron Man'
+  const response = await fetch(
+    `${process.env.GATSBY_MARVEL_ENDPOINT}v1/public/characters?orderBy=name&limit=90&name=${character}&${auth}`
+  )
+  const json = await response.json()
+  const { data = {} } = json
+
+  console.log('description', data.results[0].description)
+
+  const comics = await Promise.all(
+    data.results[0].comics.items.map(async (result) => {
+      const { resourceURI } = result
+      const comicResponse = await fetch(`${resourceURI}?${auth}`)
+      return await comicResponse.json()
+    })
+  )
+
+  console.log('comics', comics)
+}


### PR DESCRIPTION
# Changes
* Add gatsby-node file to retrieve API data during build time.
* For now, this just logs the data to the console. You could use the Gatsby Node APIs to create pages dynamically with this data.
* This would be an alternative to retrieving the data during client runtime.

<img width="732" alt="Screen Shot 2021-09-29 at 11 50 55 AM" src="https://user-images.githubusercontent.com/7364768/135331273-697c9089-4517-4b78-a8e6-be1650542e25.png">